### PR TITLE
Tidy up parsing progress logging in generateNetCDF utility

### DIFF
--- a/src/amazon/dsstne/utils/NetCDFhelper.cpp
+++ b/src/amazon/dsstne/utils/NetCDFhelper.cpp
@@ -62,8 +62,9 @@ void indexSingleFile(const string &samplesFileName,
                      map<unsigned int, vector<float>> &mSignalValues) {
 
     ifstream inputFileStream(samplesFileName);
-    timeval ts;
-    gettimeofday(&ts, NULL);
+    timeval tBegin;
+    gettimeofday(&tBegin, NULL);
+    timeval tReported = tBegin;
     string line;
     int lineNumber = 0;
 
@@ -152,11 +153,12 @@ void indexSingleFile(const string &samplesFileName,
         mSignals[sampleIndex] = signals;
         mSignalValues[sampleIndex] = signalValue;
         if (mSampleIndex.size() % gLoggingRate == 0) {
-            timeval t2;
-            gettimeofday(&t2, NULL);
-            cout << "Progress Parsing" << mSampleIndex.size();
-            cout << "Time " << elapsed_time(t2, ts) << endl;
-            gettimeofday(&ts, NULL);
+            timeval tNow;
+            gettimeofday(&tNow, NULL);
+            cout << "Progress Parsing (Sample " << mSampleIndex.size() << ", ";
+            cout << "Time " << elapsed_time(tNow, tReported) << ", ";
+            cout << "Total " << elapsed_time(tNow, tBegin) << ")" << endl;
+            tReported = tNow;
         }
     }
 }


### PR DESCRIPTION
This is a small cosmetic PR for the generateNetCDF utility, to clean up the logging output that is generated while parsing a data file.

An example of the previous output looked like this:
Progress Parsing10000Time 2.25378

With this change, the spacing has been fixed and total processing time is included:
Progress Parsing (Sample 60000, Time 2.25378, Total 13.5687)