### PR TITLE
Changes to allow NetCDFhelper unit tests to compile without CUDA-related dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,18 +5,60 @@ dist: trusty
 matrix:
   include:
     - os: linux
+      compiler: gcc
+      addons:
+        apt:
+          sources: ['ubuntu-toolchain-r-test']
+          packages: ['g++-4.8']
+      env:
+        - NETCDF_CXX4_CXXFLAGS=-Wno-write-strings
+        - OUR_CXX=g++-4.8
+        - OUR_CC=gcc-4.8
+
+    - os: linux
+      compiler: gcc
+      addons:
+        apt:
+          sources: ['ubuntu-toolchain-r-test']
+          packages: ['g++-4.9']
+      env:
+        - NETCDF_CXX4_CXXFLAGS=-Wno-write-strings
+        - OUR_CXX=g++-4.9
+        - OUR_CC=gcc-4.9
+
+    - os: linux
+      compiler: gcc
+      addons:
+        apt:
+          sources: ['ubuntu-toolchain-r-test']
+          packages: ['g++-5']
+      env:
+        - NETCDF_CXX4_CXXFLAGS=-Wno-write-strings
+        - OUR_CXX=g++-5
+        - OUR_CC=gcc-5
+
+    - os: linux
       compiler: clang
       addons:
         apt:
           sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-precise-3.7']
-          packages: ['clang-3.7', 'libcppunit-dev', 'libnetcdf-dev']
-      env: COMPILER=clang++-3.7
+          packages: ['clang-3.7']
+      env:
+        - NETCDF_CXX4_CXXFLAGS=-Wno-c++11-compat-deprecated-writable-strings
+        - OUR_CXX=clang++-3.7
+        - OUR_CC=clang-3.7
+
+before_install:
+  - sudo apt-get update -qq
+  - sudo apt-get install -qq libcppunit-dev libnetcdf-dev
 
 install:
   - wget http://www.unidata.ucar.edu/downloads/netcdf/ftp/netcdf-cxx4-4.2.tar.gz
   - tar xvf netcdf-cxx4-4.2.tar.gz
   - pushd netcdf-cxx4-4.2
-  - CXXFLAGS=-Wno-c++11-compat-deprecated-writable-strings ./configure --prefix=/usr/local
+  - export CC=$OUR_CC
+  - export CXX=$OUR_CXX
+  - CXXFLAGS=$NETCDF_CXX4_CXXFLAGS ./configure --prefix=/usr/local
   - make
   - sudo make install
   - popd

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,13 +9,21 @@ matrix:
       addons:
         apt:
           sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-precise-3.7']
-          packages: ['clang-3.7', 'libcppunit-dev']
+          packages: ['clang-3.7', 'libcppunit-dev', 'libnetcdf-dev']
       env: COMPILER=clang++-3.7
+
+install:
+  - wget http://www.unidata.ucar.edu/downloads/netcdf/ftp/netcdf-cxx4-4.2.tar.gz
+  - tar xvf netcdf-cxx4-4.2.tar.gz
+  - pushd netcdf-cxx4-4.2
+  - CXXFLAGS=-Wno-c++11-compat-deprecated-writable-strings ./configure --prefix=/usr/local
+  - make
+  - sudo make install
+  - popd
 
 script:
   - cd tst/unittests
-  - mkdir build
-  - cd build
-  - cmake .. && make
-  - ./unittests
-
+  - mkdir build && cd build
+  - cmake ..
+  - make
+  - LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib ./unittests

--- a/src/amazon/dsstne/engine/NNEnum.h
+++ b/src/amazon/dsstne/engine/NNEnum.h
@@ -1,0 +1,45 @@
+#ifndef NNENUM_H
+#define NNENUM_H
+
+namespace NNDataSetEnums {
+
+    enum Attributes
+    {
+        Sparse = 1,                 // Sparse dataset
+        Boolean = 2,                // All datapoints are 0/1
+        Unused = 4,                 // Reserved, was multinomial, but that might be implicit
+        Recurrent = 8,              // Data has a time dimension
+        Mutable = 16,               // Data can be modified by running network backwards
+        SparseIgnoreZero = 32,      // Only calculate errors and deltas on non-zero values
+    };
+
+    enum Kind
+    {
+        Numeric = 0,
+        Image = 1,
+        Audio = 2
+    };
+
+    enum Sharding
+    {
+        None = 0,
+        Model = 1,
+        Data = 2,
+    };
+
+    enum DataType
+    {
+        UInt = 0,
+        Int = 1,
+        LLInt = 2,
+        ULLInt = 3,
+        Float = 4,
+        Double = 5,
+        RGBA8 = 6,
+        RGBA16 = 7,
+        UChar = 8,
+        Char = 9
+    };
+}
+
+#endif

--- a/src/amazon/dsstne/engine/NNLayer.cpp
+++ b/src/amazon/dsstne/engine/NNLayer.cpp
@@ -165,7 +165,7 @@ void NNLayer::RefreshState(bool validate)
         _bFastSparse                = false;
         if ((_kind == Input) && (_pDataSet != NULL) && (_bSparse))
         {
-            uint32_t maxSparse      = (_pDataSet->_attributes & NNDataSetBase::Attributes::Boolean) ? getGpu()._maxSparse : getGpu()._maxSparseAnalog;
+            uint32_t maxSparse      = (_pDataSet->_attributes & NNDataSetEnums::Boolean) ? getGpu()._maxSparse : getGpu()._maxSparseAnalog;
             if (_batch > maxSparse)
             {
                 if (getGpu()._id == 0)
@@ -194,11 +194,11 @@ void NNLayer::RefreshState(bool validate)
         {
             if (_type == FullyConnected)
             {
-                _pDataSet->Shard(NNDataSetBase::Sharding::Model);
+                _pDataSet->Shard(NNDataSetEnums::Model);
             }
             else if (_type == Convolutional)
             {
-                _pDataSet->Shard(NNDataSetBase::Sharding::Data);
+                _pDataSet->Shard(NNDataSetEnums::Data);
             }
         }
         _bDirty                     = false;

--- a/src/amazon/dsstne/engine/NNTypes.cpp
+++ b/src/amazon/dsstne/engine/NNTypes.cpp
@@ -123,17 +123,17 @@ ostream& operator<< (ostream& out, const PoolingFunction& a)
 ostream& operator<< (ostream& out, PoolingFunction& p);
 
 
-static std::pair<NNDataSetBase::Kind, string> sKindPair[] =
+static std::pair<NNDataSetEnums::Kind, string> sKindPair[] =
 {
-    std::pair<NNDataSetBase::Kind, string>(NNDataSetBase::Kind::Numeric,            "Numeric"),
-    std::pair<NNDataSetBase::Kind, string>(NNDataSetBase::Kind::Image,              "Image"),
-    std::pair<NNDataSetBase::Kind, string>(NNDataSetBase::Kind::Audio,              "Audio")
+    std::pair<NNDataSetEnums::Kind, string>(NNDataSetEnums::Numeric, "Numeric"),
+    std::pair<NNDataSetEnums::Kind, string>(NNDataSetEnums::Image,   "Image"),
+    std::pair<NNDataSetEnums::Kind, string>(NNDataSetEnums::Audio,   "Audio")
 };
 
-static std::map<NNDataSetBase::Kind, string> sKindMap =
-std::map<NNDataSetBase::Kind, string>(sKindPair, sKindPair + sizeof(sKindPair) / sizeof(sKindPair[0]));
+static std::map<NNDataSetEnums::Kind, string> sKindMap =
+std::map<NNDataSetEnums::Kind, string>(sKindPair, sKindPair + sizeof(sKindPair) / sizeof(sKindPair[0]));
 
-ostream& operator<< (ostream& out, NNDataSetBase::Kind& k)
+ostream& operator<< (ostream& out, NNDataSetEnums::Kind& k)
 {
     out << sKindMap[k];
     return out;
@@ -141,118 +141,118 @@ ostream& operator<< (ostream& out, NNDataSetBase::Kind& k)
 
 
 
-static std::pair<NNDataSetBase::Attributes, string> sAttributesPair[] =
+static std::pair<NNDataSetEnums::Attributes, string> sAttributesPair[] =
 {
-    std::pair<NNDataSetBase::Attributes, string>(NNDataSetBase::Attributes::Sparse,         "Sparse"),
-    std::pair<NNDataSetBase::Attributes, string>(NNDataSetBase::Attributes::Boolean,        "Boolean"),
-    std::pair<NNDataSetBase::Attributes, string>(NNDataSetBase::Attributes::Unused,         "Reserved"),
-    std::pair<NNDataSetBase::Attributes, string>(NNDataSetBase::Attributes::Recurrent,      "Recurrent"),
-    std::pair<NNDataSetBase::Attributes, string>(NNDataSetBase::Attributes::Mutable,        "Mutable"),
+    std::pair<NNDataSetEnums::Attributes, string>(NNDataSetEnums::Sparse,    "Sparse"),
+    std::pair<NNDataSetEnums::Attributes, string>(NNDataSetEnums::Boolean,   "Boolean"),
+    std::pair<NNDataSetEnums::Attributes, string>(NNDataSetEnums::Unused,    "Reserved"),
+    std::pair<NNDataSetEnums::Attributes, string>(NNDataSetEnums::Recurrent, "Recurrent"),
+    std::pair<NNDataSetEnums::Attributes, string>(NNDataSetEnums::Mutable,   "Mutable"),
 };
 
-static std::map<NNDataSetBase::Attributes, string> sAttributesMap =
-std::map<NNDataSetBase::Attributes, string>(sAttributesPair, sAttributesPair + sizeof(sAttributesPair) / sizeof(sAttributesPair[0]));
+static std::map<NNDataSetEnums::Attributes, string> sAttributesMap =
+std::map<NNDataSetEnums::Attributes, string>(sAttributesPair, sAttributesPair + sizeof(sAttributesPair) / sizeof(sAttributesPair[0]));
 
 
-ostream& operator<< (ostream& out, NNDataSetBase::Attributes& a)
+ostream& operator<< (ostream& out, NNDataSetEnums::Attributes& a)
 {
     out << sAttributesMap[a];
     return out;
 }
 
 
-static std::pair<NNDataSetBase::Sharding, string> sShardingPair[] =
+static std::pair<NNDataSetEnums::Sharding, string> sShardingPair[] =
 {
-    std::pair<NNDataSetBase::Sharding, string>(NNDataSetBase::Sharding::None,   "None"),
-    std::pair<NNDataSetBase::Sharding, string>(NNDataSetBase::Sharding::Model,  "Model"),
-    std::pair<NNDataSetBase::Sharding, string>(NNDataSetBase::Sharding::Data,   "Data")
+    std::pair<NNDataSetEnums::Sharding, string>(NNDataSetEnums::None,  "None"),
+    std::pair<NNDataSetEnums::Sharding, string>(NNDataSetEnums::Model, "Model"),
+    std::pair<NNDataSetEnums::Sharding, string>(NNDataSetEnums::Data,  "Data")
 };
 
-static std::map<NNDataSetBase::Sharding, string> sShardingMap =
-std::map<NNDataSetBase::Sharding, string>(sShardingPair, sShardingPair + sizeof(sShardingPair) / sizeof(sShardingPair[0]));
+static std::map<NNDataSetEnums::Sharding, string> sShardingMap =
+std::map<NNDataSetEnums::Sharding, string>(sShardingPair, sShardingPair + sizeof(sShardingPair) / sizeof(sShardingPair[0]));
 
-ostream& operator<< (ostream& out, NNDataSetBase::Sharding& s)
+ostream& operator<< (ostream& out, NNDataSetEnums::Sharding& s)
 {
     out << sShardingMap[s];
     return out;
 }
 
-static std::pair<NNDataSetBase::DataType, string> sDataTypePair[] =
+static std::pair<NNDataSetEnums::DataType, string> sDataTypePair[] =
 {
-    std::pair<NNDataSetBase::DataType, string>(NNDataSetBase::DataType::UInt,   "UInt"),
-    std::pair<NNDataSetBase::DataType, string>(NNDataSetBase::DataType::Int,    "Int"),
-    std::pair<NNDataSetBase::DataType, string>(NNDataSetBase::DataType::LLInt,  "LLInt"),
-    std::pair<NNDataSetBase::DataType, string>(NNDataSetBase::DataType::ULLInt, "ULLInt"),
-    std::pair<NNDataSetBase::DataType, string>(NNDataSetBase::DataType::Float,  "Float"),
-    std::pair<NNDataSetBase::DataType, string>(NNDataSetBase::DataType::Double, "Double"),
-    std::pair<NNDataSetBase::DataType, string>(NNDataSetBase::DataType::RGBA8,  "RGBA8"),
-    std::pair<NNDataSetBase::DataType, string>(NNDataSetBase::DataType::RGBA16, "RGBA16"),
-    std::pair<NNDataSetBase::DataType, string>(NNDataSetBase::DataType::UChar,  "UChar"),
-    std::pair<NNDataSetBase::DataType, string>(NNDataSetBase::DataType::Char,   "Char"),
+    std::pair<NNDataSetEnums::DataType, string>(NNDataSetEnums::UInt,   "UInt"),
+    std::pair<NNDataSetEnums::DataType, string>(NNDataSetEnums::Int,    "Int"),
+    std::pair<NNDataSetEnums::DataType, string>(NNDataSetEnums::LLInt,  "LLInt"),
+    std::pair<NNDataSetEnums::DataType, string>(NNDataSetEnums::ULLInt, "ULLInt"),
+    std::pair<NNDataSetEnums::DataType, string>(NNDataSetEnums::Float,  "Float"),
+    std::pair<NNDataSetEnums::DataType, string>(NNDataSetEnums::Double, "Double"),
+    std::pair<NNDataSetEnums::DataType, string>(NNDataSetEnums::RGBA8,  "RGBA8"),
+    std::pair<NNDataSetEnums::DataType, string>(NNDataSetEnums::RGBA16, "RGBA16"),
+    std::pair<NNDataSetEnums::DataType, string>(NNDataSetEnums::UChar,  "UChar"),
+    std::pair<NNDataSetEnums::DataType, string>(NNDataSetEnums::Char,   "Char"),
 };
 
-static std::map<NNDataSetBase::DataType, string> sDataTypeMap =
-std::map<NNDataSetBase::DataType, string>(sDataTypePair, sDataTypePair + sizeof(sDataTypePair) / sizeof(sDataTypePair[0]));
+static std::map<NNDataSetEnums::DataType, string> sDataTypeMap =
+std::map<NNDataSetEnums::DataType, string>(sDataTypePair, sDataTypePair + sizeof(sDataTypePair) / sizeof(sDataTypePair[0]));
 
 
-ostream& operator<< (ostream& out, NNDataSetBase::DataType& t)
+ostream& operator<< (ostream& out, NNDataSetEnums::DataType& t)
 {
     out << sDataTypeMap[t];
     return out;
 }
 
-static MPI_Datatype getMPIDataType(NNDataSetBase::DataType datatype)
+static MPI_Datatype getMPIDataType(NNDataSetEnums::DataType datatype)
 {
     MPI_Datatype mpiType;
     switch (datatype)
     {
-        case NNDataSetBase::DataType::UInt:
+        case NNDataSetEnums::UInt:
             mpiType             = MPI_UINT32_T;
             break;
             
-        case NNDataSetBase::DataType::Int:
+        case NNDataSetEnums::Int:
             mpiType             = MPI_INT32_T;
             break;
             
-        case NNDataSetBase::ULLInt:
+        case NNDataSetEnums::ULLInt:
             mpiType             = MPI_UINT64_T;
             break;
             
-        case NNDataSetBase::LLInt:
+        case NNDataSetEnums::LLInt:
             mpiType             = MPI_INT64_T;
             break;
             
-        case NNDataSetBase::DataType::Float:
+        case NNDataSetEnums::Float:
             mpiType             = MPI_FLOAT;
             break;
             
-        case NNDataSetBase::DataType::Double:
+        case NNDataSetEnums::Double:
             mpiType             = MPI_DOUBLE;
             break;
     }
     return mpiType;
 }
 
-static NcType getNetCDFDataType(NNDataSetBase::DataType datatype)
+static NcType getNetCDFDataType(NNDataSetEnums::DataType datatype)
 {
     switch (datatype)
     {
-        case NNDataSetBase::DataType::UInt:
+        case NNDataSetEnums::UInt:
             return ncUint;            
             
-        case NNDataSetBase::DataType::Int:
+        case NNDataSetEnums::Int:
             return ncInt;
             
-        case NNDataSetBase::ULLInt:
+        case NNDataSetEnums::ULLInt:
             return ncUint64;
             
-        case NNDataSetBase::LLInt:
+        case NNDataSetEnums::LLInt:
             return ncInt64;
             
-        case NNDataSetBase::DataType::Float:
+        case NNDataSetEnums::Float:
             return ncFloat;
             
-        case NNDataSetBase::DataType::Double:
+        case NNDataSetEnums::Double:
             return ncDouble;
     }
 }
@@ -284,7 +284,7 @@ _width(0),
 _height(0),
 _length(0),
 _stride(0),
-_sharding(Data),
+_sharding(NNDataSetEnums::Data),
 _minX(0),
 _maxX(0),
 _sparseDataSize(0),
@@ -323,13 +323,13 @@ template<typename T> vector<tuple<uint64_t, uint64_t> > NNDataSet<T>::getMemoryU
     // Calculate per-process memory usage
     uint64_t cpuMemory                          = 0;
     uint64_t gpuMemory                          = 0;
-    if (_attributes & Sparse)
+    if (_attributes & NNDataSetEnums::Sparse)
     {
         cpuMemory                              += _examples * 2 * sizeof(uint64_t);
         gpuMemory                              += _examples * 2 * sizeof(uint64_t);
         cpuMemory                              += _vSparseIndex.size() * sizeof(uint32_t);
         gpuMemory                              += _vSparseIndex.size() * sizeof(uint32_t);
-        if (!(_attributes & Boolean))
+        if (!(_attributes & NNDataSetEnums::Boolean))
         {
             cpuMemory                          += _vSparseData.size() * sizeof(T);
             gpuMemory                          += _vSparseData.size() * sizeof(T);            
@@ -351,7 +351,7 @@ template<typename T> vector<tuple<uint64_t, uint64_t> > NNDataSet<T>::getMemoryU
 template<typename T> T NNDataSet<T>::GetDataPoint(uint32_t n, uint32_t x, uint32_t y, uint32_t z)
 {
     // Illegal to call on sparse data set
-    if (_attributes & Sparse)
+    if (_attributes & NNDataSetEnums::Sparse)
     {
         if (getGpu()._id == 0)
         {
@@ -389,7 +389,7 @@ template<typename T> T NNDataSet<T>::GetDataPoint(uint32_t n, uint32_t x, uint32
 template<typename T> bool NNDataSet<T>::SetDataPoint(T v, uint32_t n, uint32_t x, uint32_t y, uint32_t z)
 {
     // Illegal to call on sparse data set
-    if (_attributes & Sparse)
+    if (_attributes & NNDataSetEnums::Sparse)
     {
         if (getGpu()._id == 0)
         {
@@ -427,7 +427,7 @@ template<typename T> bool NNDataSet<T>::SetDataPoint(T v, uint32_t n, uint32_t x
 template<typename T> uint32_t NNDataSet<T>::GetSparseDataPoints(uint32_t n)
 {
     // Illegal to call on non-sparse data set
-    if (!(_attributes & Sparse))
+    if (!(_attributes & NNDataSetEnums::Sparse))
     {
         if (getGpu()._id == 0)
         {
@@ -454,7 +454,7 @@ template<typename T> uint32_t NNDataSet<T>::GetSparseDataPoints(uint32_t n)
 template<typename T> uint32_t NNDataSet<T>::GetSparseIndex(uint32_t n, uint32_t i)
 {
     // Illegal to call on non-sparse data set
-    if (!(_attributes & Sparse))
+    if (!(_attributes & NNDataSetEnums::Sparse))
     {
         if (getGpu()._id == 0)
         {
@@ -492,7 +492,7 @@ template<typename T> uint32_t NNDataSet<T>::GetSparseIndex(uint32_t n, uint32_t 
 template<typename T> bool NNDataSet<T>::SetSparseIndex(uint32_t n, uint32_t i, uint32_t v)
 {
     // Illegal to call on non-sparse data set
-    if (!(_attributes & Sparse))
+    if (!(_attributes & NNDataSetEnums::Sparse))
     {
         if (getGpu()._id == 0)
         {
@@ -521,7 +521,7 @@ template<typename T> bool NNDataSet<T>::SetSparseIndex(uint32_t n, uint32_t i, u
 template<typename T> T NNDataSet<T>::GetSparseDataPoint(uint32_t n, uint32_t i)
 {
     // Illegal to call on non-sparse data set
-    if (!(_attributes & Sparse))
+    if (!(_attributes & NNDataSetEnums::Sparse))
     {
         if (getGpu()._id == 0)
         {
@@ -549,7 +549,7 @@ template<typename T> T NNDataSet<T>::GetSparseDataPoint(uint32_t n, uint32_t i)
 template<typename T> bool NNDataSet<T>::SetSparseDataPoint(uint32_t n, uint32_t i, T v)
 {
     // Illegal to call on non-sparse data set
-    if (!(_attributes & Sparse))
+    if (!(_attributes & NNDataSetEnums::Sparse))
     {
         if (getGpu()._id == 0)
         {
@@ -610,7 +610,7 @@ _pbSparseTransposedData(NULL)
             }
             int dataType;
             dataTypeAtt.getValues(&dataType);
-            _dataType                           = (NNDataSetBase::DataType)dataType;
+            _dataType                           = (NNDataSetEnums::DataType)dataType;
                  
             vname                               = "attributes" + nstring;
             NcGroupAtt attributesAtt            = nfc.getAtt(vname);
@@ -625,7 +625,7 @@ _pbSparseTransposedData(NULL)
                 cout << "NNDataSet<T>::NNDataSet: Attributes:";
                 while (tempAtt != 0)
                 {
-                    NNDataSetBase::Attributes a = (NNDataSetBase::Attributes)(1 << (ffs(tempAtt) - 1));
+                    NNDataSetEnums::Attributes a = (NNDataSetEnums::Attributes)(1 << (ffs(tempAtt) - 1));
                     cout << " " << a;
                     tempAtt                    ^= 1 << (ffs(tempAtt) - 1);
                 }
@@ -702,7 +702,7 @@ _pbSparseTransposedData(NULL)
             }
                         
             // Read sparse data (type is irrelevant here)
-            if (_attributes & Sparse)
+            if (_attributes & NNDataSetEnums::Sparse)
             {
                 _vSparseStart.resize(examplesDim.getSize());
                 _vSparseEnd.resize(examplesDim.getSize());
@@ -764,7 +764,7 @@ _pbSparseTransposedData(NULL)
                 sparseIndexVar.getVar((uint32_t*)_vSparseIndex.data());
                               
                 // If not Boolean, then read templated point values
-                if (!(_attributes & Boolean))
+                if (!(_attributes & NNDataSetEnums::Boolean))
                 {                     
                     vname                       = "sparseData" + nstring;
                     NcVar sparseDataVar         = nfc.getVar(vname);
@@ -788,7 +788,7 @@ _pbSparseTransposedData(NULL)
                 vname                           = "data" + nstring;
                 NcVar dataVar                   = nfc.getVar(vname);
                 
-                if (_attributes & Boolean)
+                if (_attributes & NNDataSetEnums::Boolean)
                 {
 
                     // Read compressed boolean data then expand it
@@ -844,7 +844,7 @@ _pbSparseTransposedData(NULL)
     
     
     // Generate sparse data lookup tables if data is sparse
-    if (_attributes & Sparse)
+    if (_attributes & NNDataSetEnums::Sparse)
     {
         CalculateSparseDatapointCounts();
     }
@@ -859,7 +859,7 @@ template<typename T> bool NNDataSet<T>::Rename(const string& name)
 // Counts the number of each type of sparse datapoint for generating transposed matrices during backpropagation
 template<typename T> bool NNDataSet<T>::CalculateSparseDatapointCounts()
 {
-    if (_attributes & Sparse)
+    if (_attributes & NNDataSetEnums::Sparse)
     {
         // Calculate individual counts for each datapoint
         uint64_t N                              = _width * _height * _length;
@@ -883,7 +883,7 @@ template<typename T> bool NNDataSet<T>::CalculateSparseDatapointCounts()
         MPI_Allreduce(MPI_IN_PLACE, &_maxSparseDatapoints, 1, MPI_UINT32_T, MPI_MAX, MPI_COMM_WORLD);
 
         // Print warning message if too many datapoints for sparse kernels
-        uint32_t maxSparse      = (_attributes & Boolean) ? getGpu()._maxSparse : getGpu()._maxSparseAnalog;
+        uint32_t maxSparse      = (_attributes & NNDataSetEnums::Boolean) ? getGpu()._maxSparse : getGpu()._maxSparseAnalog;
         if (_maxSparseDatapoints > maxSparse)
         {
             if (getGpu()._id == 0)
@@ -943,7 +943,7 @@ template<typename T> bool NNDataSet<T>::GenerateSparseTransposedMatrix(uint32_t 
         _sparseTransposedIndices            = offset;
         delete _pbSparseTransposedIndex;
         _pbSparseTransposedIndex            = new GpuBuffer<uint32_t>(_sparseTransposedIndices);
-        if (!(_attributes & Boolean))
+        if (!(_attributes & NNDataSetEnums::Boolean))
         {
             delete _pbSparseTransposedData;
             _pbSparseTransposedData         = new GpuBuffer<T>(_sparseTransposedIndices);
@@ -954,7 +954,7 @@ template<typename T> bool NNDataSet<T>::GenerateSparseTransposedMatrix(uint32_t 
 
 template<typename T> bool NNDataSet<T>::SetDenoising(bool flag)
 {
-    if (!_attributes & Sparse)
+    if (!_attributes & NNDataSetEnums::Sparse)
     {
         if (getGpu()._id == 0)
         {
@@ -979,7 +979,7 @@ template<typename T> bool NNDataSet<T>::SetDenoising(bool flag)
 
 template<typename T> bool NNDataSet<T>::GenerateDenoisingData()
 {
-    if (!_attributes & Sparse)
+    if (!_attributes & NNDataSetEnums::Sparse)
     {
         if (getGpu()._id == 0)
         {
@@ -993,9 +993,9 @@ template<typename T> bool NNDataSet<T>::GenerateDenoisingData()
 
 template<typename T> bool NNDataSet<T>::UnShard()
 {
-    if (_sharding == Model)
+    if (_sharding == NNDataSetEnums::Model)
     {
-        if (_attributes & Sparse)
+        if (_attributes & NNDataSetEnums::Sparse)
         {
             // Download all current data from all GPUs
             _pbSparseStart->Download(_vSparseStart.data());
@@ -1007,7 +1007,7 @@ template<typename T> bool NNDataSet<T>::UnShard()
             _pbSparseStart                      = NULL;
             _pbSparseEnd                        = NULL;
             _pbSparseIndex                      = NULL;                 
-            if (!(_attributes & Boolean))
+            if (!(_attributes & NNDataSetEnums::Boolean))
             {
                 _pbSparseData->Download(_vSparseData.data());
                 delete _pbSparseData;
@@ -1037,7 +1037,7 @@ template<typename T> bool NNDataSet<T>::UnShard()
                 vector<uint64_t> vTempSparseEnd(_examples);
                 vector<uint32_t> vTempSparseIndex(datapoints);
                 vector<T> vTempSparseData;
-                if (!(_attributes & Boolean))
+                if (!(_attributes & NNDataSetEnums::Boolean))
                     vTempSparseData.resize(datapoints);
                 vTempSparseStart[0]             = 0;
                 uint64_t start                  = 0;
@@ -1051,7 +1051,7 @@ template<typename T> bool NNDataSet<T>::UnShard()
                     {
                         vTempSparseIndex[vTempSparseEnd[i]] 
                                                 = _vSparseIndex[vTempSparseEnd[i]];
-                        if (!(_attributes & Boolean))
+                        if (!(_attributes & NNDataSetEnums::Boolean))
                         {
                             vTempSparseData[vTempSparseEnd[i]]  
                                                 = _vSparseData[vTempSparseEnd[i]];
@@ -1071,7 +1071,7 @@ template<typename T> bool NNDataSet<T>::UnShard()
                     vector<uint32_t> vPeerSparseIndex(size);
                     MPI_Recv(&vPeerSparseIndex, size, MPI_UINT32_T, i, 0, MPI_COMM_WORLD, &status);
                     vector<T> vPeerSparseData;
-                    if (!(_attributes & Boolean))
+                    if (!(_attributes & NNDataSetEnums::Boolean))
                     {
                         vPeerSparseData.resize(size);
                         MPI_Recv(vPeerSparseData.data(), size, getMPIDataType(_dataType), i, 0, MPI_COMM_WORLD, &status);
@@ -1085,7 +1085,7 @@ template<typename T> bool NNDataSet<T>::UnShard()
                         {
                             vTempSparseIndex[vTempSparseEnd[i]] 
                                                 = vPeerSparseIndex[start];
-                            if (!(_attributes & Boolean))
+                            if (!(_attributes & NNDataSetEnums::Boolean))
                             {
                                 vTempSparseData[vTempSparseEnd[i]]  
                                                 = vPeerSparseData[start];
@@ -1098,7 +1098,7 @@ template<typename T> bool NNDataSet<T>::UnShard()
                 _vSparseStart                   = vTempSparseStart;
                 _vSparseEnd                     = vTempSparseEnd;
                 _vSparseIndex                   = vTempSparseIndex;
-                if (!(_attributes & Boolean))
+                if (!(_attributes & NNDataSetEnums::Boolean))
                     _vSparseData                = vTempSparseData;
                     
                 // Reallocate GPU data
@@ -1108,7 +1108,7 @@ template<typename T> bool NNDataSet<T>::UnShard()
                 _pbSparseStart->Upload(_vSparseStart.data());
                 _pbSparseEnd->Upload(_vSparseEnd.data());
                 _pbSparseIndex->Upload(_vSparseIndex.data());
-                if (!(_attributes & Boolean))
+                if (!(_attributes & NNDataSetEnums::Boolean))
                 {
                     _pbSparseData               = new GpuBuffer<T>((uint64_t)_vSparseData.size());
                     _pbSparseData->Upload(_vSparseData.data());           
@@ -1121,7 +1121,7 @@ template<typename T> bool NNDataSet<T>::UnShard()
                 MPI_Send(vSparseCount.data(), _examples, MPI_UINT64_T, 0, 0, MPI_COMM_WORLD);
                 MPI_Send(&size, 1, MPI_UINT64_T, 0, 0, MPI_COMM_WORLD);
                 MPI_Send(_vSparseIndex.data(), size, MPI_UINT32_T, 0, 0, MPI_COMM_WORLD);
-                if (!(_attributes & Boolean))
+                if (!(_attributes & NNDataSetEnums::Boolean))
                 {
                     MPI_Send(_vSparseData.data(), size, getMPIDataType(_dataType), 0, 0, MPI_COMM_WORLD);
                 }              
@@ -1176,11 +1176,11 @@ template<typename T> bool NNDataSet<T>::UnShard()
             
         }
     }
-    else if (_sharding == Data)
+    else if (_sharding == NNDataSetEnums::Data)
     {
     
     }
-    _sharding = None;
+    _sharding = NNDataSetEnums::None;
 
 
     // Allocate/deallocate 
@@ -1189,7 +1189,7 @@ template<typename T> bool NNDataSet<T>::UnShard()
 }
 
 
-template<typename T> bool NNDataSet<T>::Shard(NNDataSetBase::Sharding sharding)
+template<typename T> bool NNDataSet<T>::Shard(NNDataSetEnums::Sharding sharding)
 {
     // Skip if already sharded
     if (sharding == _sharding)
@@ -1199,12 +1199,12 @@ template<typename T> bool NNDataSet<T>::Shard(NNDataSetBase::Sharding sharding)
     UnShard();
 
     // Shard data out to all processes
-    if (sharding == Model)
+    if (sharding == NNDataSetEnums::Model)
     {
-        _sharding                               = Model;
+        _sharding                               = NNDataSetEnums::Model;
         _minX                                   = ((size_t)_width * (size_t)getGpu()._id) / (size_t)getGpu()._numprocs;
         _maxX                                   = ((size_t)_width * (size_t)(getGpu()._id + 1)) / (size_t)getGpu()._numprocs;    
-        if (_attributes & Sparse)
+        if (_attributes & NNDataSetEnums::Sparse)
         {
             if (getGpu()._id == 0)
             {
@@ -1226,7 +1226,7 @@ template<typename T> bool NNDataSet<T>::Shard(NNDataSetBase::Sharding sharding)
                             if ((_vSparseIndex[k] >= xmin) && (_vSparseIndex[k] < xmax)) 
                             {
                                 vLocalSparseIndex.push_back(_vSparseIndex[k] - xmin);
-                                if (!(_attributes & Boolean))
+                                if (!(_attributes & NNDataSetEnums::Boolean))
                                 {
                                     vLocalSparseData.push_back(_vSparseData[k]);
                                 }
@@ -1242,7 +1242,7 @@ template<typename T> bool NNDataSet<T>::Shard(NNDataSetBase::Sharding sharding)
                     MPI_Send(vLocalSparseStart.data(), _examples, MPI_UINT64_T, i, 0, MPI_COMM_WORLD);
                     MPI_Send(vLocalSparseEnd.data(), _examples, MPI_UINT64_T, i, 0, MPI_COMM_WORLD);
                     MPI_Send(vLocalSparseIndex.data(), size, MPI_UINT32_T, i, 0, MPI_COMM_WORLD);
-                    if (!(_attributes & Boolean))
+                    if (!(_attributes & NNDataSetEnums::Boolean))
                     {
                         MPI_Datatype mpiType        = getMPIDataType(_dataType);
                         MPI_Send(vLocalSparseData.data(), size, mpiType, i, 0, MPI_COMM_WORLD);
@@ -1266,7 +1266,7 @@ template<typename T> bool NNDataSet<T>::Shard(NNDataSetBase::Sharding sharding)
                         if ((vTempSparseIndex[k] >= _minX) && (vTempSparseIndex[k] < _maxX))
                         {
                             _vSparseIndex.push_back(vTempSparseIndex[k]);
-                            if (!(_attributes & Boolean))
+                            if (!(_attributes & NNDataSetEnums::Boolean))
                             {
                                 _vSparseData.push_back(vTempSparseData[k]);
                             }
@@ -1287,7 +1287,7 @@ template<typename T> bool NNDataSet<T>::Shard(NNDataSetBase::Sharding sharding)
                 MPI_Recv(_vSparseStart.data(), _examples, MPI_UINT64_T, 0, 0, MPI_COMM_WORLD, &status);
                 MPI_Recv(_vSparseEnd.data(), _examples, MPI_UINT64_T, 0, 0, MPI_COMM_WORLD, &status);
                 MPI_Recv(_vSparseIndex.data(), size, MPI_UINT32_T, 0, 0, MPI_COMM_WORLD, &status); 
-                if (!(_attributes & Boolean))
+                if (!(_attributes & NNDataSetEnums::Boolean))
                 {
                     MPI_Datatype mpiType            = getMPIDataType(_dataType);
                     _vSparseData.resize(size);
@@ -1305,7 +1305,7 @@ template<typename T> bool NNDataSet<T>::Shard(NNDataSetBase::Sharding sharding)
             //    printf("%6d %12d %12d\n", i, _vSparseStart[i], _vSparseEnd[i]);
             //exit(-1);
             _pbSparseIndex->Upload(_vSparseIndex.data());
-            if (!(_attributes & Boolean))
+            if (!(_attributes & NNDataSetEnums::Boolean))
             {
                 _pbSparseData                       = new GpuBuffer<T>((uint64_t)_vSparseData.size());  
                 _pbSparseData->Upload(_vSparseData.data());            
@@ -1368,7 +1368,7 @@ template<typename T> bool NNDataSet<T>::Shard(NNDataSetBase::Sharding sharding)
             _pbData->Upload(_vData.data()); 
         }
     }
-    else if (sharding == Data)
+    else if (sharding == NNDataSetEnums::Data)
     {
     
     }
@@ -1383,7 +1383,7 @@ template<typename T> bool NNDataSet<T>::SaveNetCDF(const string& fname)
     bool bResult                            = true;
 
     // Unshard data back to process 0 if necessary
-    Sharding oldSharding                    = _sharding;
+    NNDataSetEnums::Sharding oldSharding    = _sharding;
     UnShard();
 
     // Now save data entirely from process 0
@@ -1512,7 +1512,7 @@ template<typename T> bool NNDataSet<T>::WriteNetCDF(NcFile& nfc, const string& f
                 throw NcException("NcException", "NNDataSet::WriteNetCDF: Failed to write dataset example count to NetCDF file " + fname, __FILE__, __LINE__);
             } 
             
-            if (_attributes & Sparse)
+            if (_attributes & NNDataSetEnums::Sparse)
             {
                 vname                       = "sparseDataDim" + nstring;
                 NcDim sparseDataDim         = nfc.addDim(vname, _vSparseIndex.size());
@@ -1546,7 +1546,7 @@ template<typename T> bool NNDataSet<T>::WriteNetCDF(NcFile& nfc, const string& f
                 sparseIndexVar.putVar(_vSparseIndex.data());   
                 
                 // Write analog sparse values if present
-                if (!(_attributes & Boolean))
+                if (!(_attributes & NNDataSetEnums::Boolean))
                 {
                     vname                       = "sparseData" + nstring;    
                     NcType sparseType           = getNetCDFDataType(_dataType);
@@ -1574,7 +1574,7 @@ template<typename T> bool NNDataSet<T>::WriteNetCDF(NcFile& nfc, const string& f
 
 template<typename T> NNDataSet<T>::~NNDataSet()
 {
-    if (_attributes & Sparse)
+    if (_attributes & NNDataSetEnums::Sparse)
     {
         delete _pbSparseStart;
         delete _pbSparseEnd;
@@ -1582,7 +1582,7 @@ template<typename T> NNDataSet<T>::~NNDataSet()
         delete _pbSparseTransposedEnd;
         delete _pbSparseIndex;
         delete _pbSparseTransposedIndex;
-        if (!(_attributes & Boolean))
+        if (!(_attributes & NNDataSetEnums::Boolean))
         {
             delete _pbSparseData;
             delete _pbSparseTransposedData;
@@ -1601,7 +1601,7 @@ bool SaveNetCDF(const string& fname, vector<NNDataSetBase*> vDataSet)
     bool bResult                            = true;
 
     // Unshard data back to process 0 if necessary
-    vector<NNDataSetBase::Sharding> vSharding(vDataSet.size());
+    vector<NNDataSetEnums::Sharding> vSharding(vDataSet.size());
     for (uint32_t i = 0; i < vDataSet.size(); i++)
     {
         vSharding[i]                        = vDataSet[i]->_sharding;
@@ -1664,7 +1664,7 @@ bool SaveNetCDF(const string& fname, vector<NNDataSetBase*> vDataSet)
 vector<NNDataSetBase*> LoadNetCDF(const string& fname) 
 {
     vector<NNDataSetBase*> vDataSet;
-    vector<NNDataSetBase::DataType> vDataType;
+    vector<NNDataSetEnums::DataType> vDataType;
     bool bResult                                = true;
 
     if (getGpu()._id == 0)
@@ -1697,17 +1697,17 @@ vector<NNDataSetBase*> LoadNetCDF(const string& fname)
                 dataTypeAtt.getValues(&dataType);   
                 switch (dataType)
                 {
-                    case NNDataSetBase::DataType::UInt:
-                    case NNDataSetBase::DataType::Int:
-                    case NNDataSetBase::DataType::LLInt:
-                    case NNDataSetBase::DataType::ULLInt:
-                    case NNDataSetBase::DataType::Float:
-                    case NNDataSetBase::DataType::Double:
-                    case NNDataSetBase::DataType::RGBA8:
-                    case NNDataSetBase::DataType::RGBA16:
-                    case NNDataSetBase::DataType::UChar:
-                    case NNDataSetBase::DataType::Char:
-                        vDataType.push_back((NNDataSetBase::DataType)dataType);
+                    case NNDataSetEnums::UInt:
+                    case NNDataSetEnums::Int:
+                    case NNDataSetEnums::LLInt:
+                    case NNDataSetEnums::ULLInt:
+                    case NNDataSetEnums::Float:
+                    case NNDataSetEnums::Double:
+                    case NNDataSetEnums::RGBA8:
+                    case NNDataSetEnums::RGBA16:
+                    case NNDataSetEnums::UChar:
+                    case NNDataSetEnums::Char:
+                        vDataType.push_back((NNDataSetEnums::DataType)dataType);
                         break;
                         
                     default:
@@ -1752,27 +1752,27 @@ vector<NNDataSetBase*> LoadNetCDF(const string& fname)
             cout << "LoadNetCDF: Loading " << vDataType[i] << " data set" << endl; 
         switch (vDataType[i])
         {
-            case NNDataSetBase::UInt:
+            case NNDataSetEnums::UInt:
                 pDataSet                    = new NNDataSet<uint32_t>(fname, i);
                 break;
 
-            case NNDataSetBase::Int:
+            case NNDataSetEnums::Int:
                 pDataSet                    = new NNDataSet<long>(fname, i);
                 break;
 
-            case NNDataSetBase::Float:
+            case NNDataSetEnums::Float:
                 pDataSet                    = new NNDataSet<float>(fname, i);
                 break;
 
-            case NNDataSetBase::Double:
+            case NNDataSetEnums::Double:
                 pDataSet                    = new NNDataSet<double>(fname, i);
                 break;
 
-            case NNDataSetBase::Char:
+            case NNDataSetEnums::Char:
                 pDataSet                    = new NNDataSet<char>(fname, i);
                 break;
 
-            case NNDataSetBase::UChar:
+            case NNDataSetEnums::UChar:
                 pDataSet                    = new NNDataSet<unsigned char>(fname, i);
                 break;
 

--- a/src/amazon/dsstne/utils/NetCDFhelper.cpp
+++ b/src/amazon/dsstne/utils/NetCDFhelper.cpp
@@ -22,9 +22,8 @@
 #include <unordered_map>
 #include <stdexcept>
 
+#include "NNEnum.h"
 #include "Utils.h"
-#include "GpuTypes.h"
-#include "NNTypes.h"
 
 using namespace std;
 using namespace netCDF;
@@ -319,9 +318,9 @@ void writeNetCDFFile(vector<unsigned int> &vSparseStart,
         }
         nc.putAtt("datasets", ncUint, 1);
         nc.putAtt("name0", datasetName);
-        nc.putAtt("attributes0", ncUint, NNDataSetBase::Attributes::Sparse);
-        nc.putAtt("kind0", ncUint, NNDataSetBase::Kind::Numeric);
-        nc.putAtt("dataType0", ncUint, NNDataSetBase::DataType::Float);
+        nc.putAtt("attributes0", ncUint, NNDataSetEnums::Sparse);
+        nc.putAtt("kind0", ncUint, NNDataSetEnums::Numeric);
+        nc.putAtt("dataType0", ncUint, NNDataSetEnums::Float);
         nc.putAtt("dimensions0", ncUint, 1);
         nc.putAtt("width0", ncUint, maxFeatureIndex);
         NcDim examplesDim = nc.addDim("examplesDim0", vSparseStart.size());
@@ -363,9 +362,9 @@ void writeNetCDFFile(vector<unsigned int> &vSparseStart,
         }
         nc.putAtt("datasets", ncUint, 1);
         nc.putAtt("name0", datasetName);
-        nc.putAtt("attributes0", ncUint, (NNDataSetBase::Attributes::Sparse + NNDataSetBase::Attributes::Boolean));
-        nc.putAtt("kind0", ncUint, NNDataSetBase::Kind::Numeric);
-        nc.putAtt("dataType0", ncUint, NNDataSetBase::DataType::UInt);
+        nc.putAtt("attributes0", ncUint, (NNDataSetEnums::Sparse + NNDataSetEnums::Boolean));
+        nc.putAtt("kind0", ncUint, NNDataSetEnums::Numeric);
+        nc.putAtt("dataType0", ncUint, NNDataSetEnums::UInt);
         nc.putAtt("dimensions0", ncUint, 1);
         nc.putAtt("width0", ncUint, maxFeatureIndex);
         NcDim examplesDim = nc.addDim("examplesDim0", vSparseStart.size());

--- a/src/amazon/dsstne/utils/NetCDFhelper.h
+++ b/src/amazon/dsstne/utils/NetCDFhelper.h
@@ -10,33 +10,21 @@
    or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
-#include <cstdio>
-#include <algorithm>
-#include <cstring>
-#include <iostream>
-#include <fstream>
-#include <sstream>
+#include <string>
 #include <vector>
-#include <map>
-#include <netcdf>
-#include <sys/time.h>
 #include <unordered_map>
-
-using namespace std;
-using namespace netCDF;
-using namespace netCDF::exceptions;
 
 /**
  * Loads an index from the given indexFileName files, assuming an entry on each line with a 
  * tab separating label and index. Used for feature and sample indices for a dataset.
  */
-void loadIndex(unordered_map<string, unsigned int> &mLabelToIndex, string indexFileName);
+void loadIndex(std::unordered_map<std::string, unsigned int> &mLabelToIndex, std::string indexFileName);
 
 /**
  * Exports an index to the given indexFileName files, writing an entry to each line with a 
  * tab separating label and index. Used for feature and sample indices for a dataset.
  */
-void exportIndex(unordered_map<string, unsigned int> &mLabelToIndex, string indexFileName);
+void exportIndex(std::unordered_map<std::string, unsigned int> &mLabelToIndex, std::string indexFileName);
 
 /**
  * Updates the index information from the samplesFile into the referenced data structures.
@@ -44,16 +32,16 @@ void exportIndex(unordered_map<string, unsigned int> &mLabelToIndex, string inde
  * featureIndexUpdated and sampleIndexUpdated will be true iff feature and sample indices have been updated (respectively)
  *
  */
-void indexFile(const string &samplesPath,
+void indexFile(const std::string &samplesPath,
                const bool enableFeatureIndexUpdates,
-               unordered_map<string, unsigned int> &mFeatureIndex,
-               unordered_map<string, unsigned int> &mSampleIndex,
+               std::unordered_map<std::string, unsigned int> &mFeatureIndex,
+               std::unordered_map<std::string, unsigned int> &mSampleIndex,
                bool &featureIndexUpdated,
                bool &sampleIndexUpdated,
-               vector<unsigned int> &vSparseStart,
-               vector<unsigned int> &vSparseEnd,
-               vector<unsigned int> &vSparseIndex,
-               vector<float> &vSparseData);
+               std::vector<unsigned int> &vSparseStart,
+               std::vector<unsigned int> &vSparseEnd,
+               std::vector<unsigned int> &vSparseIndex,
+               std::vector<float> &vSparseData);
 
 /**
  * Generates a NetCDF index for a given dataset and exports them to respective files with 
@@ -68,16 +56,16 @@ void indexFile(const string &samplesPath,
  * @param outFeatureIndexFileName - the name of the file to export the feature index to.
  * @param outSampleIndexFileName - the name of tile to export the samples index to.
  */
-void generateNetCDFIndexes(const string &samplesPath,
+void generateNetCDFIndexes(const std::string &samplesPath,
                            const bool enableFeatureIndexUpdates,
-                           const string &outFeatureIndexFileName,
-                           const string &outSampleIndexFileName,
-                           unordered_map<string, unsigned int> &mFeatureIndex,
-                           unordered_map<string, unsigned int> &mSampleIndex,
-                           vector<unsigned int> &vSparseStart,
-                           vector<unsigned int> &vSparseEnd,
-                           vector<unsigned int> &vSparseIndex,
-                           vector<float> &vSparseData);
+                           const std::string &outFeatureIndexFileName,
+                           const std::string &outSampleIndexFileName,
+                           std::unordered_map<std::string, unsigned int> &mFeatureIndex,
+                           std::unordered_map<std::string, unsigned int> &mSampleIndex,
+                           std::vector<unsigned int> &vSparseStart,
+                           std::vector<unsigned int> &vSparseEnd,
+                           std::vector<unsigned int> &vSparseIndex,
+                           std::vector<float> &vSparseData);
 
 /**
  * Generates a NetCDF index for a given dataset and exports them to respective files, using 
@@ -87,37 +75,37 @@ void generateNetCDFIndexes(const string &samplesPath,
  *  - outFeatureIndexFileName = $datasetName.inputIndex
  *  - outSampleIndexFileName = $datasetName.sampleIndex
  */
-void generateNetCDFIndexes(const string &samplesFileName,
+void generateNetCDFIndexes(const std::string &samplesFileName,
                            const bool enableFeatureIndexUpdates,
-                           const string &dataSetName,
-                           unordered_map<string, unsigned int> &mFeatureIndex,
-                           unordered_map<string, unsigned int> &mSampleIndex,
-                           vector<unsigned int> &vSparseStart,
-                           vector<unsigned int> &vSparseEnd,
-                           vector<unsigned int> &vSparseIndex,
-                           vector<float> &vSparseValue);
+                           const std::string &dataSetName,
+                           std::unordered_map<std::string, unsigned int> &mFeatureIndex,
+                           std::unordered_map<std::string, unsigned int> &mSampleIndex,
+                           std::vector<unsigned int> &vSparseStart,
+                           std::vector<unsigned int> &vSparseEnd,
+                           std::vector<unsigned int> &vSparseIndex,
+                           std::vector<float> &vSparseValue);
 
 /**
  * Writes an NetCDFfile for a given sparse matrix of indices and values (start of sample, end of sample, samples array) for each sample.
  * The dataset within the file is indexed with dataset name. Note that maxFeatureIndex is the rounded up to multiple of 32.
  */
-void writeNetCDFFile(vector<unsigned int> &vSparseStart,
-                     vector<unsigned int> &vSparseEnd,
-                     vector<unsigned int> &vSparseIndex,
-                     vector<float> &vSparseValue,
-                     string fileName,
-                     string datasetName,
+void writeNetCDFFile(std::vector<unsigned int> &vSparseStart,
+                     std::vector<unsigned int> &vSparseEnd,
+                     std::vector<unsigned int> &vSparseIndex,
+                     std::vector<float> &vSparseValue,
+                     std::string fileName,
+                     std::string datasetName,
                      unsigned int maxFeatureIndex);
 
 /**
  * Writes an NetCDFfile for a given sparse matrix of indices only (start of sample, end of sample, samples array) for each sample.
  * The dataset within the file is indexed with dataset name. Note that maxFeatureIndex is the rounded up to multiple of 32.
  */
-void writeNetCDFFile(vector<unsigned int> &vSparseStart,
-                     vector<unsigned int> &vSparseEnd,
-                     vector<unsigned int> &vSparseIndex,
-                     string fileName,
-                     string datasetName,
+void writeNetCDFFile(std::vector<unsigned int> &vSparseStart,
+                     std::vector<unsigned int> &vSparseEnd,
+                     std::vector<unsigned int> &vSparseIndex,
+                     std::string fileName,
+                     std::string datasetName,
                      unsigned int maxFeatureIndex);
 
 /**
@@ -125,12 +113,8 @@ void writeNetCDFFile(vector<unsigned int> &vSparseStart,
  */
 unsigned int roundUpMaxIndex(unsigned int maxFeatureIndex);
 
-std::vector<std::string> &split(const std::string &s, char delim, std::vector<std::string> &elems);
-
-std::vector<std::string> split(const std::string &s, char delim);
-
 /**
  * Returns the absolute paths of all files in the directory. If the directory is a file, then returns a singleton
  * of the file itself.
  */
-int listFiles(const string &dirname, const bool recursive, vector<string> &files);
+int listFiles(const std::string &dirname, const bool recursive, std::vector<std::string> &files);

--- a/tst/unittests/CMakeLists.txt
+++ b/tst/unittests/CMakeLists.txt
@@ -4,6 +4,22 @@ project (amazon-dsstne)
 
 ################################################################################
 #
+# Compiler configuration
+#
+################################################################################
+
+include(CheckCXXCompilerFlag)
+
+CHECK_CXX_COMPILER_FLAG("-std=c++11" COMPILER_SUPPORTS_CXX11)
+
+if(COMPILER_SUPPORTS_CXX11)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+else()
+    message(FATAL_ERROR "Your compiler ${CMAKE_CXX_COMPILER} has no C++11 support. Please use a different C++ compiler.")
+endif()
+
+################################################################################
+#
 # Dependencies
 #
 ################################################################################
@@ -11,6 +27,8 @@ project (amazon-dsstne)
 find_package(PkgConfig)
 
 PKG_CHECK_MODULES(CPPUNIT REQUIRED cppunit)
+PKG_CHECK_MODULES(NETCDF REQUIRED netcdf)
+PKG_CHECK_MODULES(NETCDF_CXX4 REQUIRED netcdf-cxx4)
 
 ################################################################################
 #
@@ -18,14 +36,19 @@ PKG_CHECK_MODULES(CPPUNIT REQUIRED cppunit)
 #
 ################################################################################
 
+set(ENGINE_DIR ../../src/amazon/dsstne/engine)
 set(UTILS_DIR ../../src/amazon/dsstne/utils)
 
 include_directories(
+    ${ENGINE_DIR}
     ${UTILS_DIR}
     ${CPPUNIT_INCLUDE_DIR}
+    ${NETCDF_INCLUDE_DIR}
+    ${NETCDF_CXX4_INCLUDE_DIR}
 )
 
 set(UTILS_SOURCES
+    ${UTILS_DIR}/NetCDFhelper.cpp
     ${UTILS_DIR}/Utils.cpp
 )
 
@@ -40,4 +63,6 @@ add_executable(unittests
 
 target_link_libraries(unittests
     ${CPPUNIT_LIBRARIES}
+    ${NETCDF_LIBRARIES}
+    ${NETCDF_CXX4_LIBRARIES}
 )


### PR DESCRIPTION
This PR includes a set of changes that will allow tests for NetCDFhelper.cpp/h to be included in the unit test suite without pulling in CUDA-related dependencies. I recommend reviewing the PR by commit, as each commit neatly captures a set of changes that I have made.

The first and most significant change was to lift the nested enum types from NNDataSet (NNTypes.h) into a separate header file (NNEnum.h). This has two advantages:
* The NNEnum.h has no external dependencies other than the STL, so it can be easily used outside of engine code. As it is, these enum values were the only declarations from NNTypes.h that were used in NetCDFhelper.
* It becomes clear which namespace/class the enum values should be qualified with. Most of the changes in this commit are to correctly qualify usage of those enum values.

The second commit tidies up NetCDFhelper.h. This should all be pretty self-explanatory.

Finally, the third commit updates the unit test build and Travis CI configuration to bring in the necessary NetCDF dependencies to compile NetCDFhelper.cpp.

