### PR TITLE
NetCDF validation improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,17 @@ matrix:
         - OUR_CXX=clang++-3.7
         - OUR_CC=clang-3.7
 
+    - os: linux
+      compiler: clang
+      addons:
+        apt:
+          sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-precise-3.8']
+          packages: ['clang-3.8']
+      env:
+        - NETCDF_CXX4_CXXFLAGS=-Wno-c++11-compat-deprecated-writable-strings
+        - OUR_CXX=clang++-3.8
+        - OUR_CC=clang-3.8
+
 before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -qq libcppunit-dev libnetcdf-dev

--- a/src/amazon/dsstne/utils/NetCDFGenerator.cpp
+++ b/src/amazon/dsstne/utils/NetCDFGenerator.cpp
@@ -94,22 +94,20 @@ int main(int argc, char **argv) {
         cout << "Will create a new samples index file: " << sampleIndexFile << endl;
     } else {
         cout << "Loading sample index from: " << sampleIndexFile << endl;
-        loadIndex(mSampleIndex, sampleIndexFile);
-        cout << "Num entries: " << mSampleIndex.size() << endl;
+        if (!loadIndexFromFile(mSampleIndex, sampleIndexFile, cout)) {
+            exit(1);
+        }
     }
 
     if (createFeatureIndex) {
-        // create a brand new index file and export it to 
         cout << "Will create a new features index file: " << featureIndexFile << endl;
+    } else if (!fileExists(featureIndexFile)) {
+        cout << "Error: Cannnot find a valid feature index file: " << featureIndexFile << endl;
+        exit(1);
     } else {
-        // Will load an existing feature index file.
-        if (!fileExists(featureIndexFile)) {
-            cout << "Error: Cannnot find a valid feature index file: " << featureIndexFile << endl;
+        cout << "Loading feature index from: " << featureIndexFile << endl;
+        if (!loadIndexFromFile(mFeatureIndex, featureIndexFile, cout)) {
             exit(1);
-        } else {
-            cout << "Loading features index from: " << featureIndexFile << endl;
-            loadIndex(mFeatureIndex, featureIndexFile);
-            cout << "Num entries: " << mFeatureIndex.size() << endl;
         }
     }
 

--- a/src/amazon/dsstne/utils/NetCDFhelper.cpp
+++ b/src/amazon/dsstne/utils/NetCDFhelper.cpp
@@ -12,6 +12,7 @@
 
 #include <cstdio>
 #include <algorithm>
+#include <cerrno>
 #include <cstring>
 #include <iostream>
 #include <fstream>
@@ -38,8 +39,13 @@ bool loadIndex(std::unordered_map<string, unsigned int> &labelsToIndices, std::i
     const size_t initialIndexSize = labelsToIndices.size();
     while (getline(inputStream, line)) {
         vector<string> vData = split(line, '\t');
-        labelsToIndices[vData[0]] = atoi(vData[1].c_str());
         linesProcessed++;
+        if (vData.size() == 2 && !vData[0].empty()) {
+            labelsToIndices[vData[0]] = atoi(vData[1].c_str());
+        } else {
+            outputStream << "Error: line " << linesProcessed << " contains invalid data" << endl;
+            return false;
+        }
     }
 
     const size_t numEntriesAdded = labelsToIndices.size() - initialIndexSize;
@@ -50,8 +56,8 @@ bool loadIndex(std::unordered_map<string, unsigned int> &labelsToIndices, std::i
         return false;
     }
 
-    if (inputStream.fail()) {
-        outputStream << "Error: Failed to read all data from input stream" << endl;
+    if (inputStream.bad()) {
+        outputStream << "Error: " << strerror(errno) << endl;
         return false;
     }
 

--- a/src/amazon/dsstne/utils/NetCDFhelper.h
+++ b/src/amazon/dsstne/utils/NetCDFhelper.h
@@ -10,15 +10,43 @@
    or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
 
+#include <iosfwd>
 #include <string>
 #include <vector>
 #include <unordered_map>
 
 /**
- * Loads an index from the given indexFileName files, assuming an entry on each line with a 
+ * Loads an index from the given input stream, assuming an entry on each line with a 
  * tab separating label and index. Used for feature and sample indices for a dataset.
+
+ * This function performs additional error checks to ensure that the number of lines
+ * processed matches the number of entries added to the index. This is will detect
+ * data corruption issues, but will not necessarily identify the exact line that
+ * is causing the issue.
+ *
+ * @param labelsToIndices  unordered_map into which new entries will be inserted
+ * @param inputStream      input stream from which to read raw data
+ * @param outputStream     output stream to be used for any status or error messages
+ *
+ * @return \c true if all input is processed successfully; \c false otherwise
  */
-void loadIndex(std::unordered_map<std::string, unsigned int> &mLabelToIndex, std::string indexFileName);
+bool loadIndex(std::unordered_map<std::string, unsigned int> &mLabelToIndex, std::istream &inputStream,
+               std::ostream &outputStream);
+
+/**
+ * Loads an index from the given input file, assuming an entry on each line with a
+ * tab separating label and index. Used for feature and sample indices for a dataset.
+ *
+ * Error checking is as described for the loadIndex() function.
+ *
+ * @param labelsToIndices  unordered_map into which new entries will be inserted
+ * @param inputFile        path to file from which to read raw data
+ * @param outputStream     output stream to be used for any status or error messages
+ *
+ * @return  \c true if the entire input file was read successfully; \c false otherwise
+ */
+bool loadIndexFromFile(std::unordered_map<std::string, unsigned int> &labelsToIndices, const std::string &inputFile,
+                       std::ostream &outputStream);
 
 /**
  * Exports an index to the given indexFileName files, writing an entry to each line with a 

--- a/src/amazon/dsstne/utils/Predict.cpp
+++ b/src/amazon/dsstne/utils/Predict.cpp
@@ -178,9 +178,10 @@ int main(int argc, char** argv)
     gettimeofday(&timePreProcessingStart, NULL);
 
     unordered_map<string, unsigned int> mInput;
-    // Load dataset
-    loadIndex(mInput, inputIndexFileName);
-    cout << "Loaded input feature index with " << mInput.size() << " entries." << endl;
+    cout << "Loading input feature index from: " << inputIndexFileName << endl;
+    if (!loadIndexFromFile(mInput, inputIndexFileName, cout)) {
+        exit(1);
+    }
 
     // Load the dataset text file and geneate the NetCDF
     unordered_map<string, unsigned int> mSignals;
@@ -221,8 +222,11 @@ int main(int argc, char** argv)
     // For output recs, we cannot assume the input and output layers have identical
     // features or even ordering. So, we load the index for output layer.
     unordered_map<string, unsigned int> mOutput;
-    loadIndex(mOutput, outputIndexFileName);
-    cout << "Loaded output feature index with " << mOutput.size() << " entries." << endl;
+    cout << "Loading output feature index from: " << outputIndexFileName << endl;
+    if (!loadIndexFromFile(mOutput, outputIndexFileName, cout)) {
+        exit(1);
+    }
+    
     vector<string> vOutput(mOutput.size());
     extractNNMapsToVectors(vOutput, mOutput);
     FilterConfig* vFilterSet = loadFilters(filtersFileName,recsOutputFileName, mOutput, mSignals);

--- a/tst/unittests/TestNetCDFhelper.cpp
+++ b/tst/unittests/TestNetCDFhelper.cpp
@@ -1,10 +1,124 @@
+#include <map>
+#include <string>
+#include <sstream>
+#include <unordered_map>
+
 #include <cppunit/extensions/HelperMacros.h>
 #include <cppunit/ui/text/TestRunner.h>
 #include <cppunit/TestAssert.h>
 
+#include "NetCDFhelper.h"
+
+using namespace std;
+
 class TestNetCDFhelper : public CppUnit::TestFixture
 {
+    const static map<string, unsigned int> validFeatureIndex;
+
 public:
+    void TestLoadIndexWithValidInput() {
+        // Seed the input stream with valid input
+        stringstream inputStream;
+        for (const auto &entry : validFeatureIndex) {
+            inputStream << entry.first << "\t" << entry.second << "\n";
+        }
+
+        unordered_map<string, unsigned int> labelsToIndices;
+        stringstream outputStream;
+        CPPUNIT_ASSERT(loadIndex(labelsToIndices, inputStream, outputStream));
+        CPPUNIT_ASSERT_MESSAGE("Output stream should contain no error messages", 
+            outputStream.str().find("Error") == string::npos);
+        CPPUNIT_ASSERT_MESSAGE("Number of entries in feature index should be equal to number of lines of input",
+            validFeatureIndex.size() == labelsToIndices.size());
+
+        // Check that all of the feature map entries have been correctly loaded
+        for (const auto &entry : validFeatureIndex) {
+            const auto itr = labelsToIndices.find(entry.first);
+            CPPUNIT_ASSERT_MESSAGE("Each feature label from input should be present in feature index",
+                itr != labelsToIndices.end());
+            CPPUNIT_ASSERT_MESSAGE("Each feature index from input should be present in feature index",
+                entry.second == itr->second);
+        }
+    }
+
+    void TestLoadIndexWithDuplicateEntry() {
+        // Seed the input stream with valid input
+        stringstream inputStream;
+        for (const auto &entry : validFeatureIndex) {
+            inputStream << entry.first << "\t" << entry.second << "\n";
+        }
+
+        // Duplicate first entry
+        const auto itr = validFeatureIndex.begin();
+        inputStream << validFeatureIndex.begin()->first << "\t" << itr->second << "\n";
+
+        unordered_map<string, unsigned int> labelsToIndices;
+        stringstream outputStream;
+        CPPUNIT_ASSERT(!loadIndex(labelsToIndices, inputStream, outputStream));
+        CPPUNIT_ASSERT_MESSAGE("Output stream should contain an error message", 
+            outputStream.str().find("Error") != string::npos);
+    }
+
+    void TestLoadIndexWithDuplicateLabelOnly() {
+        // Seed the input stream with valid input
+        stringstream inputStream;
+        for (const auto &entry : validFeatureIndex) {
+            inputStream << entry.first << "\t" << entry.second << "\n";
+        }
+
+        // Duplicate just the label used in the first entry
+        inputStream << validFeatureIndex.begin()->first << "\t123\n";
+
+        unordered_map<string, unsigned int> labelsToIndices;
+        stringstream outputStream;
+        CPPUNIT_ASSERT(!loadIndex(labelsToIndices, inputStream, outputStream));
+        CPPUNIT_ASSERT_MESSAGE("Output stream should contain an error message", 
+            outputStream.str().find("Error") != string::npos);
+    }
+
+    void TestLoadIndexWithMissingLabel() {
+        stringstream inputStream;
+        inputStream << "\t123\n";
+        unordered_map<string, unsigned int> labelsToIndices;
+        stringstream outputStream;
+        CPPUNIT_ASSERT(!loadIndex(labelsToIndices, inputStream, outputStream));
+        CPPUNIT_ASSERT_MESSAGE("Output stream should contain an error message", 
+            outputStream.str().find("Error") != string::npos);
+    }
+
+    void TestLoadIndexWithMissingLabelAndTab() {
+        stringstream inputStream;
+        inputStream << "123\n";
+        unordered_map<string, unsigned int> labelsToIndices;
+        stringstream outputStream;
+        CPPUNIT_ASSERT(!loadIndex(labelsToIndices, inputStream, outputStream));
+        CPPUNIT_ASSERT_MESSAGE("Output stream should contain an error message", 
+            outputStream.str().find("Error") != string::npos);
+    }
+
+    void TestLoadIndexWithExtraTab() {
+        stringstream inputStream;
+        inputStream << "110510\t123\t121017\n";
+        unordered_map<string, unsigned int> labelsToIndices;
+        stringstream outputStream;
+        CPPUNIT_ASSERT(!loadIndex(labelsToIndices, inputStream, outputStream));
+        CPPUNIT_ASSERT_MESSAGE("Output stream should contain an error message", 
+            outputStream.str().find("Error") != string::npos);
+    }
+
     CPPUNIT_TEST_SUITE(TestNetCDFhelper);
+    CPPUNIT_TEST(TestLoadIndexWithValidInput);
+    CPPUNIT_TEST(TestLoadIndexWithDuplicateEntry);
+    CPPUNIT_TEST(TestLoadIndexWithDuplicateLabelOnly);
+    CPPUNIT_TEST(TestLoadIndexWithMissingLabel);
+    CPPUNIT_TEST(TestLoadIndexWithMissingLabelAndTab);
+    CPPUNIT_TEST(TestLoadIndexWithExtraTab);
     CPPUNIT_TEST_SUITE_END();
 };
+
+const map<string, unsigned int> TestNetCDFhelper::validFeatureIndex = {
+    { "110510", 26743 },
+    { "121019", 26740 },
+    { "121017", 26739 },
+    { "106401", 26736 },
+    { "104307", 26734 }};


### PR DESCRIPTION
This PR addresses https://github.com/amznlabs/amazon-dsstne/issues/65 by improving the validation applied when loading feature and sample index files. And to aid in testing, the original `loadIndex` function has been refactored to read from a `std::istream` rather than directly from a file. We even have unit tests!

These changes apply to both the 'generateNetCDF' and 'predict' utilities. Both have been to use a newly added `loadIndexFromFile` helper function.

Also included is a minor change to the Travis CI build that adds support for clang 3.8.

I've tested all of these changes against the problematic dataset from issue https://github.com/amznlabs/amazon-dsstne/issues/62 and the MovieLens dataset with de-noising disabled. The new code correctly identifies errors in the issue 62 dataset, and shows no regressions for the MovieLens dataset.


