### PR TITLE
Update Dockerfile and Setup guide to point to version 1.8.12 of hdf5 library

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,9 +60,9 @@ RUN cd /tmp  && \
 
 #Installing hdf5
 RUN cd /tmp && \
-    wget ftp://ftp.unidata.ucar.edu/pub/netcdf/netcdf-4/hdf5-1.8.9.tar.gz && \
-    tar xvfz hdf5-1.8.9.tar.gz && \
-    cd hdf5-1.8.9 && \
+    wget ftp://ftp.unidata.ucar.edu/pub/netcdf/netcdf-4/hdf5-1.8.12.tar.gz && \
+    tar xvfz hdf5-1.8.12.tar.gz && \
+    cd hdf5-1.8.12 && \
     ./configure --prefix=/usr/local &&\
     make && \
     make install && rm -rf /tmp/*

--- a/docs/getting_started/setup.md
+++ b/docs/getting_started/setup.md
@@ -106,9 +106,9 @@ NetCDF is the format which is supported inherently from DSSTNE engine. It is req
 #### HDF5 Setup
 ```bash
 # Ubuntu/Linux 64-bit
-wget ftp://ftp.unidata.ucar.edu/pub/netcdf/netcdf-4/hdf5-1.8.9.tar.gz
-tar xvfz hdf5-1.8.9.tar.gz
-cd hdf5-1.8.9
+wget ftp://ftp.unidata.ucar.edu/pub/netcdf/netcdf-4/hdf5-1.8.12.tar.gz
+tar xvfz hdf5-1.8.12.tar.gz
+cd hdf5-1.8.12
 ./configure --prefix=/usr/local
 make
 sudo make install


### PR DESCRIPTION
This is just a minor PR to resolve issue https://github.com/amznlabs/amazon-dsstne/issues/71.

These are the only references to a specific version of the hdf5 library in the DSSTNE source.