### PR TITLE
Fix 'redefinition of default argument' warning in Utils.cpp and merge conflicts

### DIFF
--- a/src/amazon/dsstne/utils/Utils.cpp
+++ b/src/amazon/dsstne/utils/Utils.cpp
@@ -277,7 +277,7 @@ bool cmpSecond(const pair<Tkey, Tval>& left, const pair<Tkey, Tval>& right) {
 }
 
 template<typename Tkey, typename Tval>
-void topKsort(Tkey* keys, Tval* vals, const int size, Tkey* topKkeys, Tval* topKvals, const int topK, const bool sortByKey = true) {
+void topKsort(Tkey* keys, Tval* vals, const int size, Tkey* topKkeys, Tval* topKvals, const int topK, const bool sortByKey) {
   if (!keys || !topKkeys || !topKvals) {
     cout << "null input array" << endl;
     exit(0);

--- a/tst/gputests/TestDune.cpp
+++ b/tst/gputests/TestDune.cpp
@@ -4,15 +4,7 @@
 // STL
 #include <string>
 
-<<<<<<< Updated upstream
-#include "TestGpu.cpp"
-<<<<<<< Updated upstream
 #include "TestSort.cpp"
-=======
-=======
-#include "TestSort.cpp"
->>>>>>> Stashed changes
->>>>>>> Stashed changes
 
 /**
  * In order to write a new test case, create a Test<File>.cpp and write the test
@@ -25,14 +17,6 @@
 
 int main() {
     CppUnit::TextUi::TestRunner runner;
-<<<<<<< Updated upstream
-    runner.addTest(TestGpu::suite());
-<<<<<<< Updated upstream
     runner.addTest(TestSort::suite());
-=======
-=======
-    runner.addTest(TestSort::suite());
->>>>>>> Stashed changes
->>>>>>> Stashed changes
     return !runner.run();
 }

--- a/tst/gputests/TestSort.cpp
+++ b/tst/gputests/TestSort.cpp
@@ -5,11 +5,6 @@
 // STL
 #include <string>
 
-<<<<<<< Updated upstream
-#include "Utils.h"
-
-
-=======
 #include "GpuTypes.h"
 #include "NNTypes.h"
 #include "kernels.h"
@@ -17,7 +12,6 @@
 
 
 using namespace std;
->>>>>>> Stashed changes
 
 void randData(NNFloat* pTarget, NNFloat* pOut, const size_t batch, const size_t nFeatures, const size_t stride) {
   memset(pTarget, 0, stride * batch * sizeof(NNFloat));


### PR DESCRIPTION
This PR removes some merge conflict markup (caused by incorrect use of git stash) that was accidentally included in the previous commit.

It also fixes a compiler warning caused by the redefinition of a default argument in one of the function templates added to Utils.cpp.