### PR TITLE
Allow GPU test suite to be built using CMake

### DIFF
--- a/tst/gputests/CMakeLists.txt
+++ b/tst/gputests/CMakeLists.txt
@@ -1,0 +1,92 @@
+cmake_minimum_required (VERSION 3.2)
+
+project (amazon-dsstne)
+
+################################################################################
+#
+# Check for C++11 support
+#
+################################################################################
+
+include(CheckCXXCompilerFlag)
+
+CHECK_CXX_COMPILER_FLAG("-std=c++11" COMPILER_SUPPORTS_CXX11)
+
+if(!COMPILER_SUPPORTS_CXX11)
+    message(FATAL_ERROR "Your compiler ${CMAKE_CXX_COMPILER} has no C++11 support. Please use a different C++ compiler.")
+endif()
+
+################################################################################
+#
+# Dependencies
+#
+################################################################################
+
+find_package(CUDA)
+find_package(MPI)
+find_package(PkgConfig)
+
+PKG_CHECK_MODULES(CPPUNIT REQUIRED cppunit)
+PKG_CHECK_MODULES(NETCDF REQUIRED netcdf)
+PKG_CHECK_MODULES(NETCDF_CXX4 REQUIRED netcdf-cxx4)
+
+################################################################################
+#
+# Compiler flags
+#
+################################################################################
+
+SET(CUDA_PROPAGATE_HOST_FLAGS OFF)
+set(CUDA_NVCC_FLAGS "${CMAKE_CXX_FLAGS} ${CUDA_NVCC_FLAGS} -use_fast_math -gencode arch=compute_50,code=sm_50 -gencode arch=compute_30,code=sm_30 -DOMPI_SKIP_MPICXX -std=c++11")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+
+################################################################################
+#
+# Test suite
+#
+################################################################################
+
+set(ENGINE_DIR ../../src/amazon/dsstne/engine)
+set(UTILS_DIR ../../src/amazon/dsstne/utils)
+
+include_directories(
+    ${ENGINE_DIR}
+    ${UTILS_DIR}
+    ${CPPUNIT_INCLUDE_DIR}
+    ${CUDA_INCLUDE_DIRS}
+    ${MPI_CXX_INCLUDE_PATH}
+    ${NETCDF_INCLUDE_DIR}
+    ${NETCDF_CXX4_INCLUDE_DIR}
+)
+
+set(ENGINE_SOURCES
+    ${ENGINE_DIR}/GpuTypes.cpp
+    ${ENGINE_DIR}/kernels.cu
+    ${ENGINE_DIR}/kActivation.cu
+    ${ENGINE_DIR}/kDelta.cu
+    ${ENGINE_DIR}/kLoss.cu
+)
+
+set(UTILS_SOURCES
+    ${UTILS_DIR}/Utils.cpp
+)
+
+set(TEST_SOURCES
+    TestDune.cpp
+)
+
+cuda_add_executable(gputests
+    ${ENGINE_SOURCES}
+    ${TEST_SOURCES}
+    ${UTILS_SOURCES}
+)
+
+target_link_libraries(gputests
+    ${CPPUNIT_LIBRARIES}
+    ${CUDA_CUBLAS_LIBRARIES}
+    ${CUDA_curand_LIBRARY}
+    ${CUDA_LIBRARIES}
+    ${MPI_CXX_LIBRARIES}
+    ${NETCDF_LIBRARIES}
+    ${NETCDF_CXX4_LIBRARIES}
+)

--- a/tst/gputests/TestDune.cpp
+++ b/tst/gputests/TestDune.cpp
@@ -16,7 +16,12 @@
  */
 
 int main() {
+    getGpu().Startup(0, NULL);
+    getGpu().SetRandomSeed(12345);
+    getGpu().CopyConstants();
     CppUnit::TextUi::TestRunner runner;
     runner.addTest(TestSort::suite());
-    return !runner.run();
+    const bool result = runner.run();
+    getGpu().Shutdown();
+    return result ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/tst/gputests/TestSort.cpp
+++ b/tst/gputests/TestSort.cpp
@@ -211,9 +211,6 @@ class TestSort : public CppUnit::TestFixture
 public:             // Interface
     void            TestCPU_GPUSort()
     {
-      // Initialize GPU
-      getGpu().SetRandomSeed(12345);
-      getGpu().CopyConstants();
       {
         const size_t BATCH = 128;
         const size_t TOP_K = 128;
@@ -249,7 +246,6 @@ public:             // Interface
         bool result = testTopK(BATCH, TOP_K, N_FEATURES);
         CPPUNIT_ASSERT_MESSAGE("failed with N_FEATURES = 64, TOP_K = 32", result);
       }
-      //getGpu().Shutdown();
     }
     
 public:


### PR DESCRIPTION
This PR adds a CMakeLists file that allows the GPU test suite to be built using CMake - assuming that CUDA Toolkit, cuDNN and other dependencies have been installed.

The test suite can be built without an NVIDIA GPU. This can be useful, for example, when you want to validate that GPU-related code changes compile before incurring the cost of testing them on EC2.

Obviously, running the test suite requires a compatible GPU to be installed in the system.

Note that I have tested this on a g2.2xlarge EC2 instance, and found that some of the existing tests fail. This will require further investigation, but should not block us from merging this PR.

