### PR TITLE
The destructor of a base class should be virtual.

### DIFF
--- a/src/amazon/dsstne/utils/Filters.cpp
+++ b/src/amazon/dsstne/utils/Filters.cpp
@@ -25,6 +25,10 @@
 using namespace Json;
 using namespace std;
 
+AbstractFilter::~AbstractFilter()
+{
+}
+
 /**
         Updates the records in the array with the filters
         x[Index] =  x[Index] * (filterValue for that index)

--- a/src/amazon/dsstne/utils/Filters.h
+++ b/src/amazon/dsstne/utils/Filters.h
@@ -24,6 +24,7 @@ using namespace std;
 class AbstractFilter
 {
 public:
+    virtual ~AbstractFilter();
     virtual void loadFilter(unordered_map<string, unsigned int>& ,
                             unordered_map<string, unsigned int>& ,
                             string ) = 0;


### PR DESCRIPTION
Scott meyers saids desturctor shoudl be virtual if it is a base class and has virtual methods.

Actually there is no reason that AbstractFilter is a base class, because FilterConfig uses SamplesFilter directly instead of using AbstractFilter as an interface.

If you have a plan to make more Filter who implements AbstractFilter, AbstractFilter destructor should be virtual.
If not, I recommend to merge AbstractFilter and SamplesFilter.