### PR TITLE
Build fix

### DIFF
--- a/src/amazon/dsstne/engine/GpuTypes.cpp
+++ b/src/amazon/dsstne/engine/GpuTypes.cpp
@@ -470,7 +470,7 @@ void GpuContext::SetNeuralNetwork(NNNetwork* pNetwork)
     _data._SMCE_zeroTarget                          = pNetwork->_SMCE_zeroTarget;
     _data._SMCE_oneScale                            = pNetwork->_SMCE_oneScale;
     _data._SMCE_zeroScale                           = pNetwork->_SMCE_zeroScale;
-    _data._bShuffleIndices                          = pNetwork->_bShuffleIndices && (pNetwork->_mode == NNNetwork::Mode::Training);
+    _data._bShuffleIndices                          = pNetwork->_bShuffleIndices && (pNetwork->_mode == Mode::Training);
     _data._pShuffleIndex                            = pNetwork->_pShuffleIndex;
     CopyConstants();
 }


### PR DESCRIPTION
There is a build error in most recent build.

```
GpuTypes.cpp: In member function ‘void GpuContext::SetNeuralNetwork(NNNetwork*)’:
GpuTypes.cpp:473:116: error: ‘NNNetwork::Mode’ has not been declared
     _data._bShuffleIndices                          = pNetwork->_bShuffleIndices && (pNetwork->_mode == NNNetwork::Mode::Training);
                                                                                                                    ^
Makefile:37: recipe for target 'GpuTypes.o' failed
```

so I included omitted changes from pull request #100