### PR TITLE
numerical gradient validation for cost functions

### DIFF
--- a/src/amazon/dsstne/engine/NNNetwork.cpp
+++ b/src/amazon/dsstne/engine/NNNetwork.cpp
@@ -2312,14 +2312,23 @@ void NNNetwork::CalculatePropagationOrder()
 // Validates network gradients numerically
 bool NNNetwork::Validate()
 {
-    // below parameters are used only for numerical gradient validation (non centered formula TODO),
+    // below parameters are used only for numerical gradient validation (non centered formula),
     // that is why neural network will be tested only in SGD mode
     bool result                 = true;
     const NNFloat delta  = (NNFloat)0.001;
     const NNFloat alpha  = (NNFloat)1.0;
     const NNFloat lambda = (NNFloat)0.0; // regularization parameter (no need for bias test)
     const NNFloat mu     = (NNFloat)0.0; // no momentum
-    const NNFloat epsilon = delta * 10.f;
+
+    // There are couple of issues with numerical gradient validation:
+    // The deeper network the higher numerical error in the cost function evaluation;
+    // Current implementation uses non centered derivative formula and it is not the best choice (TODO).
+    // Because of these two reasons threshold tuning becomes empirical,
+    // and the goal is choose value as small as possible so that probability of unit test failure
+    // in case when gradient implementation is correct should be zero
+    // and probability of detection of incorrect gradient implementation should be as high as possible.
+    // On deeper networks threshold 10 gives false positive failures even though gradient implementation is correct. So I set to 20
+    const NNFloat epsilon = delta * 20.f;
 
     // Only runs in single-processor mode
     if (getGpu()._numprocs > 1)

--- a/tst/gputests/TestCostFunctions.cpp
+++ b/tst/gputests/TestCostFunctions.cpp
@@ -1,0 +1,64 @@
+// CppUnit
+#include "cppunit/extensions/HelperMacros.h"
+#include "cppunit/ui/text/TestRunner.h"
+#include "cppunit/TestAssert.h"
+// STL
+#include <string>
+
+#include "Utils.h"
+#include "GpuTypes.h"
+#include "NNTypes.h"
+#include "TestUtils.h"
+
+class TestCostFunctions: public CppUnit::TestFixture {
+public:
+    // Interface
+    void testCostFunctions() {
+        // Initialize GPU
+        getGpu().SetRandomSeed(12345);
+        getGpu().CopyConstants();
+
+        // test data scaled marginal cross entropy
+        {
+            const size_t batch = 2;
+            const string modelPath = std::string(TEST_DATA_PATH) + "validate_DataScaledMarginalCrossEntropy_02.json";
+            DataParameters dataParameters;
+            dataParameters.numberOfSamples = 1024;
+            dataParameters.inpFeatureDimensionality = 2;
+            dataParameters.outFeatureDimensionality = 2;
+            bool result = validateNeuralNetwork(batch, modelPath, ClassificationAnalog, dataParameters, std::cout);
+            CPPUNIT_ASSERT_MESSAGE("failed on DataScaledMarginalCrossEntropy", result);
+        }
+
+        // test marginal cross entropy
+        {
+            const size_t batch = 4;
+            const string modelPath = std::string(TEST_DATA_PATH) + "validate_ScaledMarginalCrossEntropy_02.json";
+            DataParameters dataParameters;
+            dataParameters.numberOfSamples = 1024;
+            dataParameters.inpFeatureDimensionality = 2;
+            dataParameters.outFeatureDimensionality = 2;
+            bool result = validateNeuralNetwork(batch, modelPath, Classification, dataParameters, std::cout);
+            CPPUNIT_ASSERT_MESSAGE("failed on DataScaledMarginalCrossEntropy", result);
+        }
+
+        // test L2
+        {
+            const size_t batch = 4;
+            const string modelPath = std::string(TEST_DATA_PATH) + "validate_L2_02.json";
+            DataParameters dataParameters;
+            dataParameters.numberOfSamples = 1024;
+            dataParameters.inpFeatureDimensionality = 1;
+            dataParameters.outFeatureDimensionality = 1;
+            dataParameters.W0 = -2.f;
+            dataParameters.B0 = 3.f;
+            bool result = validateNeuralNetwork(batch, modelPath, Regression, dataParameters, std::cout);
+            CPPUNIT_ASSERT_MESSAGE("failed on DataScaledMarginalCrossEntropy", result);
+        }
+    }
+
+public:
+    CPPUNIT_TEST_SUITE(TestCostFunctions);
+    CPPUNIT_TEST(testCostFunctions);
+    CPPUNIT_TEST_SUITE_END();
+};

--- a/tst/gputests/TestDune.cpp
+++ b/tst/gputests/TestDune.cpp
@@ -6,6 +6,7 @@
 
 #include "TestSort.cpp"
 #include "TestActivationFunctions.cpp"
+#include "TestCostFunctions.cpp"
 
 /**
  * In order to write a new test case, create a Test<File>.cpp and write the test
@@ -23,6 +24,7 @@ int main() {
     CppUnit::TextUi::TestRunner runner;
     runner.addTest(TestSort::suite());
     runner.addTest(TestActivationFunctions::suite());
+    runner.addTest(TestCostFunctions::suite());
     const bool result = runner.run();
     getGpu().Shutdown();
     return result ? EXIT_SUCCESS : EXIT_FAILURE;


### PR DESCRIPTION
validate several cost functions, and set threshold multiplier back to 20 because of numerical truncation.
All unit tests are successful.